### PR TITLE
Add dependabot config

### DIFF
--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,0 +1,73 @@
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: "/dotnet"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 3
+  target-branch: master
+  reviewers:
+    - echarrod
+    - LAFYoti
+    - jlmartyres
+    - nikhilPank
+
+- package-ecosystem: composer
+  directory: "/php"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 3
+  target-branch: master
+  reviewers:
+    - echarrod
+    - LAFYoti
+    - jlmartyres
+    - nikhilPank
+  
+- package-ecosystem: gomod
+  directory: "/go"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 3
+  target-branch: master
+  reviewers:
+    - echarrod
+    - LAFYoti
+    - jlmartyres
+    - nikhilPank
+
+- package-ecosystem: maven
+  directory: "/java"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 3
+  target-branch: master
+  reviewers:
+    - echarrod
+    - LAFYoti
+    - jlmartyres
+    - nikhilPank
+
+- package-ecosystem: npm
+  directory: "/javascript"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 3
+  target-branch: master
+  reviewers:
+    - echarrod
+    - LAFYoti
+    - jlmartyres
+    - nikhilPank
+
+- package-ecosystem: pip
+  directory: "/python"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 3
+  target-branch: master
+  reviewers:
+    - echarrod
+    - LAFYoti
+    - jlmartyres
+    - nikhilPank


### PR DESCRIPTION
## Why 
- We have automated security fixes created (e.g. https://github.com/getyoti/age-scan-examples/pull/2), but these don't get addressed as no one is assigned them, or a review requested. Also by default, dependabot doesn't scan multiple package managers, so this config file would mean we scan each example. 

- Current schedule is monthly, 3 PRs max. Security update PRs are created immediately though, and are excluded from this update schedule